### PR TITLE
Stagger producer client startup

### DIFF
--- a/producer/main.go
+++ b/producer/main.go
@@ -74,6 +74,10 @@ func main() {
 			}
 			fmt.Printf("Connected to %s\n", tcpServer)
 
+			rand.Seed(time.Now().UnixNano())
+
+      			time.Sleep(time.Duration(rand.Intn(1000000) + 1) * time.Microsecond)
+			
 			ticker := time.NewTicker(time.Duration(*messageInterval) * time.Second)
 			for range ticker.C {
 				payload := map[string]int64{


### PR DESCRIPTION
I think this does what I want it to :)

I guess with starting up all the producer tickers at the same time there will be a batch of 2500 messages published every 1 second using -s 2500 -p 1. I assume adding a little random sleep before each ticker start will balance them out instead of batches.